### PR TITLE
 Preserving newlines & carriage returns 

### DIFF
--- a/logstash/1000_nessus_process_file.conf
+++ b/logstash/1000_nessus_process_file.conf
@@ -19,22 +19,30 @@ filter {
     # Drop the header column
     if [message] =~ "^Plugin ID" { drop {} }
 
-    mutate {
-      gsub => [
-        "message", "\|\|\|", " ",
-        "message", "\t\t", " ",
-        "message", "    ", " ",
-        "message", "   ", " ",
-        "message", "  ", " "
-      ]
-    }
-
     csv {
       columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output"]
       separator => ","
       source => "message"
     }
     
+    ruby {
+        code => "if event.get('description')
+                    event.set('description', event.get('description').gsub(92.chr + 'n', 10.chr).gsub(92.chr + 'r', 13.chr))
+                end
+                 if event.get('synopsis')
+                    event.set('synopsis', event.get('synopsis').gsub(92.chr + 'n', 10.chr).gsub(92.chr + 'r', 13.chr))
+                end
+                 if event.get('solution')
+                    event.set('solution', event.get('solution').gsub(92.chr + 'n', 10.chr).gsub(92.chr + 'r', 13.chr))
+                end
+                 if event.get('see_also')
+                    event.set('see_also', event.get('see_also').gsub(92.chr + 'n', 10.chr).gsub(92.chr + 'r', 13.chr))
+                end
+                 if event.get('plugin_output')
+                    event.set('plugin_output', event.get('plugin_output').gsub(92.chr + 'n', 10.chr).gsub(92.chr + 'r', 13.chr))
+                end"
+    }
+	
     #If using filebeats as your source, you will need to replace the "path" field to "source"
     grok {
       match => { "path" => "(?<scan_name>[a-zA-Z0-9_.\-]+)_%{INT:scan_id}_%{INT:history_id}_%{INT:last_updated}.csv$" }

--- a/vulnwhisp/vulnwhisp.py
+++ b/vulnwhisp/vulnwhisp.py
@@ -131,7 +131,7 @@ class vulnWhispererBase(object):
         self.create_table()
 
     def cleanser(self, _data):
-        repls = (('\n', '|||'), ('\r', '|||'), (',', ';'))
+        repls = (('\n', r'\n'), ('\r', r'\r'))
         data = reduce(lambda a, kv: a.replace(*kv), repls, _data)
         return data
 


### PR DESCRIPTION
While the output from Nessus contains a lot of whitespace, I find that removing it makes the results harder to read.
The same can be done for Tabs, but it doesn't seem to be necessary.

P.S. I've tested this with the beats input (filebeat >> logstash).