### PR TITLE
Update template to version 5.x

### DIFF
--- a/elasticsearch/logstash-vulnwhisperer-template.json
+++ b/elasticsearch/logstash-vulnwhisperer-template.json
@@ -57,73 +57,59 @@
           "type": "integer"
         },
         "last_updated": {
-          "type": "date",
-          "doc_values": true
+          "type": "date"
         },
         "geoip": {
           "dynamic": true,
           "type": "object",
           "properties": {
             "ip": {
-              "type": "ip",
-              "doc_values": true
+              "type": "ip"
             },
             "latitude": {
-              "type": "float",
-              "doc_values": true
+              "type": "float"
             },
             "location": {
-              "type": "geo_point",
-              "doc_values": true
+              "type": "geo_point"
             },
             "longitude": {
-              "type": "float",
-              "doc_values": true
+              "type": "float"
             }
           }
         },
         "risk_score": {
           "type": "float"
         },
-        "source": {
-          "index": "not_analyzed",
-          "type": "string"
+        "source": {          
+          "type": "keyword"
         },
         "synopsis": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
         },
         "see_also": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
         },
         "@timestamp": {
-          "type": "date",
-          "doc_values": true
+          "type": "date"
         },
         "cve": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
         },
         "solution": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
         },
         "port": {
           "index": "not_analyzed",
           "type": "integer"
         },
         "host": {
-          "type": "string"
+          "type": "text"
         },
         "@version": {
-          "index": "not_analyzed",
-          "type": "string",
-          "doc_values": true
+          "type": "keyword"
         },
         "risk": {
-          "index": "not_analyzed",
-          "type": "string"
+          "type": "keyword"
         },
         "assign_ip": {
           "type": "ip"

--- a/elasticsearch/logstash-vulnwhisperer-template.json
+++ b/elasticsearch/logstash-vulnwhisperer-template.json
@@ -21,8 +21,7 @@
   "mappings": {
     "_default_": {
       "_all": {
-        "enabled": true,
-        "norms": false
+        "enabled": false
       },
       "dynamic_templates": [
         {
@@ -99,7 +98,6 @@
           "type": "keyword"
         },
         "port": {
-          "index": "not_analyzed",
           "type": "integer"
         },
         "host": {


### PR DESCRIPTION
- Disable _all field because it's no longer needed in 5.6.x. When _all is disabled, the search query is executed on all fields if certain conditions are matched (can't remember this feature name)
- Replace not_analyzed fields with keyword type
- Fix one wrong integer mapping