### PR TITLE
Fix closing logging handlers

### DIFF
--- a/bin/vuln_whisperer
+++ b/bin/vuln_whisperer
@@ -74,7 +74,7 @@ def main():
 
             	vw.whisper_vulnerabilities()
             # TODO: fix this to NOT be exit 1 unless in error
-            close_logging_handlers()
+            close_logging_handlers(logger)
 	    sys.exit(1)
 
         else:
@@ -89,7 +89,7 @@ def main():
 
             vw.whisper_vulnerabilities()
             # TODO: fix this to NOT be exit 1 unless in error
-            close_logging_handlers()
+            close_logging_handlers(logger)
             sys.exit(1)
 
     except Exception as e:
@@ -98,12 +98,12 @@ def main():
             logger.error('{}'.format(str(e)))
             print('ERROR: {error}'.format(error=e))
         # TODO: fix this to NOT be exit 2 unless in error
-        close_logging_handlers()
+        close_logging_handlers(logger)
         sys.exit(2)
 
-    close_logging_handlers()
+    close_logging_handlers(logger)
 
-def close_logging_handlers():
+def close_logging_handlers(logger):
     for handler in logger.handlers:
         handler.close()
         logger.removeFilter(handler)


### PR DESCRIPTION
Fix closing the logging handlers. The logger variable is locally scoped to the main function, we're trying to close it from within another function.

```
INFO:vulnWhispererNessus:Scan aggregation complete! Connection to database closed.
ERROR:root:global name 'logger' is not defined
ERROR: global name 'logger' is not defined
Traceback (most recent call last):
  File "/usr/local/bin/vuln_whisperer", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/tmp/VulnWhisperer-pemontto/bin/vuln_whisperer", line 112, in <module>
    main()
  File "/tmp/VulnWhisperer-pemontto/bin/vuln_whisperer", line 101, in main
    close_logging_handlers()
  File "/tmp/VulnWhisperer-pemontto/bin/vuln_whisperer", line 107, in close_logging_handlers
    for handler in logger.handlers:
NameError: global name 'logger' is not defined
```