### PR TITLE
Fix missing sys import

### DIFF
--- a/vulnwhisp/frameworks/qualys_vuln.py
+++ b/vulnwhisp/frameworks/qualys_vuln.py
@@ -3,6 +3,7 @@
 __author__ = 'Nathan Young'
 
 import xml.etree.ElementTree as ET
+import sys
 import logging
 import qualysapi
 import pandas as pd


### PR DESCRIPTION
Using sys.exit(1) over plain exit(1). Updating imports to support this should fix the CI failure.