### PR TITLE
Feature separate qualys

### DIFF
--- a/configs/frameworks_example.ini
+++ b/configs/frameworks_example.ini
@@ -26,7 +26,7 @@ enabled = true
 hostname = qualysapi.qg2.apps.qualys.com
 username = exampleuser
 password = examplepass
-write_path=/opt/VulnWhisperer/data/qualys/
+write_path=/opt/VulnWhisperer/data/qualys_web/
 db_path=/opt/VulnWhisperer/data/database
 verbose=true
 
@@ -42,15 +42,9 @@ enabled = true
 hostname = qualysapi.qg2.apps.qualys.com
 username = exampleuser
 password = examplepass
-write_path=/opt/VulnWhisperer/data/qualys/
+write_path=/opt/VulnWhisperer/data/qualys_vuln/
 db_path=/opt/VulnWhisperer/data/database
 verbose=true
-
-# Set the maximum number of retries each connection should attempt.
-#Note, this applies only to failed connections and timeouts, never to requests where the server returns a response.
-max_retries = 10
-# Template ID will need to be retrieved for each document. Please follow the reference guide above for instructions on how to get your template ID.
-template_id = 126024
 
 [detectify]
 #Reference https://developer.detectify.com/
@@ -73,20 +67,6 @@ password = examplepass
 write_path=/opt/VulnWhisperer/data/openvas/
 db_path=/opt/VulnWhisperer/data/database
 verbose=true
-
-#[proxy]
-; This section is optional. Leave it out if you're not using a proxy.
-; You can use environmental variables as well: http://www.python-requests.org/en/latest/user/advanced/#proxies
-
-; proxy_protocol set to https, if not specified.
-#proxy_url = proxy.mycorp.com
-
-; proxy_port will override any port specified in proxy_url
-#proxy_port = 8080
-
-; proxy authentication
-#proxy_username = proxyuser
-#proxy_password = proxypass
 
 [jira]
 enabled = false

--- a/configs/test.ini
+++ b/configs/test.ini
@@ -26,7 +26,7 @@ enabled = false
 hostname = qualys_web
 username = exampleuser
 password = examplepass
-write_path=/tmp/VulnWhisperer/data/qualys/
+write_path=/tmp/VulnWhisperer/data/qualys_web/
 db_path=/tmp/VulnWhisperer/data/database
 verbose=true
 
@@ -42,15 +42,9 @@ enabled = true
 hostname = qualys_vuln
 username = exampleuser
 password = examplepass
-write_path=/tmp/VulnWhisperer/data/qualys/
+write_path=/tmp/VulnWhisperer/data/qualys_vuln/
 db_path=/tmp/VulnWhisperer/data/database
 verbose=true
-
-# Set the maximum number of retries each connection should attempt.
-#Note, this applies only to failed connections and timeouts, never to requests where the server returns a response.
-max_retries = 10
-# Template ID will need to be retrieved for each document. Please follow the reference guide above for instructions on how to get your template ID.
-template_id = 126024
 
 [detectify]
 #Reference https://developer.detectify.com/
@@ -73,20 +67,6 @@ password = examplepass
 write_path=/tmp/VulnWhisperer/data/openvas/
 db_path=/tmp/VulnWhisperer/data/database
 verbose=true
-
-#[proxy]
-; This section is optional. Leave it out if you're not using a proxy.
-; You can use environmental variables as well: http://www.python-requests.org/en/latest/user/advanced/#proxies
-
-; proxy_protocol set to https, if not specified.
-#proxy_url = proxy.mycorp.com
-
-; proxy_port will override any port specified in proxy_url
-#proxy_port = 8080
-
-; proxy authentication
-#proxy_username = proxyuser
-#proxy_password = proxypass
 
 [jira]
 enabled = false

--- a/resources/elk5-old_compatibility/logstash/1000_nessus_process_file.conf
+++ b/resources/elk5-old_compatibility/logstash/1000_nessus_process_file.conf
@@ -27,7 +27,7 @@ filter {
 
     csv {
       # columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output"]
-      columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output", "asset_uuid", "vulnerability_state", "ip", "fqdn", "netbios", "operating_system", "mac_address", "plugin_family", "cvss_base", "cvss_temporal", "cvss_temporal_vector", "cvss_vector", "cvss3_base", "cvss3_temporal", "cvss3_temporal_vector", "cvss_vector", "system_type", "host_start", "host_end"]
+      columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output", "asset_uuid", "vulnerability_state", "ip", "fqdn", "netbios", "operating_system", "mac_address", "plugin_family", "cvss_base", "cvss_temporal", "cvss_temporal_vector", "cvss_vector", "cvss3_base", "cvss3_temporal", "cvss3_temporal_vector", "cvss3_vector", "system_type", "host_start", "host_end"]
       separator => ","
       source => "message"
     }

--- a/resources/elk5-old_compatibility/logstash/2000_qualys_web_scans.conf
+++ b/resources/elk5-old_compatibility/logstash/2000_qualys_web_scans.conf
@@ -6,7 +6,7 @@
 
 input {
   file {
-    path => "/opt/vulnwhisperer/qualys/*.json"
+    path => [ "/opt/vulnwhisperer/data/qualys/*.json" , "/opt/vulnwhisperer/data/qualys_web/*.json", "/opt/vulnwhisperer/data/qualys_vuln/*.json" ]
     type => json
     codec => json
     start_position => "beginning"

--- a/resources/elk6/pipeline/1000_nessus_process_file.conf
+++ b/resources/elk6/pipeline/1000_nessus_process_file.conf
@@ -29,7 +29,7 @@ filter {
 
     csv {
       # columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output"]
-      columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output", "asset_uuid", "vulnerability_state", "ip", "fqdn", "netbios", "operating_system", "mac_address", "plugin_family", "cvss_base", "cvss_temporal", "cvss_temporal_vector", "cvss_vector", "cvss3_base", "cvss3_temporal", "cvss3_temporal_vector", "cvss_vector", "system_type", "host_start", "host_end"]
+      columns => ["plugin_id", "cve", "cvss", "risk", "asset", "protocol", "port", "plugin_name", "synopsis", "description", "solution", "see_also", "plugin_output", "asset_uuid", "vulnerability_state", "ip", "fqdn", "netbios", "operating_system", "mac_address", "plugin_family", "cvss_base", "cvss_temporal", "cvss_temporal_vector", "cvss_vector", "cvss3_base", "cvss3_temporal", "cvss3_temporal_vector", "cvss3_vector", "system_type", "host_start", "host_end"]
       separator => ","
       source => "message"
     }

--- a/resources/elk6/pipeline/2000_qualys_web_scans.conf
+++ b/resources/elk6/pipeline/2000_qualys_web_scans.conf
@@ -6,7 +6,7 @@
 
 input {
   file {
-    path => "/opt/vulnwhisperer/data/qualys/*.json"
+    path => [ "/opt/vulnwhisperer/data/qualys/*.json" , "/opt/vulnwhisperer/data/qualys_web/*.json", "/opt/vulnwhisperer/data/qualys_vuln/*.json"] 
     type => json
     codec => json
     start_position => "beginning"
@@ -14,7 +14,6 @@ input {
     mode => "read"
     start_position => "beginning"
     file_completed_action => "delete"
-
   }
 }
 


### PR DESCRIPTION
* Fix Tenable cvss3_vector in Logstash config
* Separate qualys_web and qualys_vuln data
* Remove redundant config

TODO: update documentation to detail how a proxy can be used across frameworks.
```
export HTTP_PROXY=http://example.com:8080
export HTTPS_PROXY=http://example.com:8080
```