### PR TITLE
Target CentOS 7 (issue #199)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:latest
+FROM centos:7
 
 MAINTAINER Justin Henderson justin@hasecuritysolutions.com
 


### PR DESCRIPTION
Quick fix to target CentOS 7 in Docker for Python 2 support.  Alternatively, the Python commands could be changed to `python2`.  This is a band-aid until Python 3 support can be considered.